### PR TITLE
Add "ANY" allowed value for /ValueTypes/AWS::Glue::Trigger.Predicate.Logical.

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -45,7 +45,8 @@
     "path": "/ValueTypes/AWS::Glue::Trigger.Predicate.Logical",
     "value": {
       "AllowedValues": [
-        "AND"
+        "AND",
+        "ANY"
       ]
     }
   },


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

According to the [AWS::Glue::Trigger documentation](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-Predicate), `AWS::Glue::Trigger.Predicate.Logical` can take two values: "ANY" or "AND". The current schema only allows "AND". 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
